### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Calamus.TaskScheduler/Calamus.TaskScheduler.csproj
+++ b/Calamus.TaskScheduler/Calamus.TaskScheduler.csproj
@@ -29,14 +29,14 @@
     <PackageReference Include="CronExpressionDescriptor" Version="2.16.0" />
     <PackageReference Include="FluentEmail.Core" Version="2.9.0" />
     <PackageReference Include="FluentEmail.Smtp" Version="2.9.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.4.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.4.0" />
-    <PackageReference Include="MySql.Data" Version="8.0.22" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.10.0" />
-    <PackageReference Include="Quartz" Version="3.2.3" />
-    <PackageReference Include="Quartz.AspNetCore" Version="3.2.3" />
-    <PackageReference Include="Quartz.Plugins.TimeZoneConverter" Version="3.2.3" />
-    <PackageReference Include="Quartz.Serialization.Json" Version="3.2.3" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.5.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="9.5.2" />
+    <PackageReference Include="MySql.Data" Version="8.0.25" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.11.0" />
+    <PackageReference Include="Quartz" Version="3.3.2" />
+    <PackageReference Include="Quartz.AspNetCore" Version="3.3.2" />
+    <PackageReference Include="Quartz.Plugins.TimeZoneConverter" Version="3.3.0" />
+    <PackageReference Include="Quartz.Serialization.Json" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@246850, I found an issue in the Calamus.TaskScheduler.csproj:

Packages FluentValidation.AspNetCore v9.4.0, FluentValidation.DependencyInjectionExtensions v9.4.0, MySql.Data v8.0.22, NLog.Web.AspNetCore v4.10.0, Quartz v3.2.3, Quartz.AspNetCore v3.2.3, Quartz.Plugins.TimeZoneConverter v3.2.3 and Quartz.Serialization.Json v3.2.3 transitively introduce 108 dependencies into Calamus.TaskScheduler’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Calamus-TaskScheduler.html)), while FluentValidation.AspNetCore v9.5.1, FluentValidation.DependencyInjectionExtensions v9.5.2, MySql.Data v8.0.25, NLog.Web.AspNetCore v4.11.0, Quartz v3.3.2, Quartz.AspNetCore v3.3.2, Quartz.Plugins.TimeZoneConverter v3.3.0 and Quartz.Serialization.Json v3.3.1 can only introduce 51 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Calamus-TaskScheduler_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose